### PR TITLE
Allow the plugin to be installed on more recent IDE builds

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,7 +32,7 @@
     <version>0.1.3</version>
     <depends>com.intellij.modules.platform</depends>
     <!-- Minimum and maximum build of IDE compatible with the plugin -->
-    <idea-version since-build="202" until-build="202.*"/>
+    <idea-version since-build="202" />
     <extensions defaultExtensionNs="com.intellij">
         <!-- Add your extensions here -->
         <fileType name="Diagrams.net Diagram" implementationClass="de.docs_as_co.intellij.plugin.drawio.DiagramsNetFileType"


### PR DESCRIPTION
There's a good chance newer build still have all the APIs necessary for the plugin to function so it's best to only set until-build when it's known to be broken or there's newer plugin version that is specifically targeting newer IDE builds.